### PR TITLE
feat: ephemeralStorageSize to 10GB for cases that need to update trivy DB

### DIFF
--- a/src/image-scanner-with-trivy.ts
+++ b/src/image-scanner-with-trivy.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { CustomResource, Duration, Token } from 'aws-cdk-lib';
+import { CustomResource, Duration, Size, Token } from 'aws-cdk-lib';
 import { IRepository } from 'aws-cdk-lib/aws-ecr';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import {
@@ -236,6 +236,7 @@ export class ImageScannerWithTrivy extends Construct {
       timeout: Duration.seconds(900),
       retryAttempts: 0,
       memorySize: props.memorySize ?? DEFAULT_MEMORY_SIZE,
+      ephemeralStorageSize: Size.gibibytes(10), // for cases that need to update DB: /tmp/trivy/db/trivy.db
     });
     props.repository.grantPull(customResourceLambda);
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -24,6 +24,9 @@ exports[`ImageScannerWithTrivy Snapshot test 1`] = `
             "Fn::Sub": "registry.hub.docker.com/library/busybox",
           },
         },
+        "EphemeralStorage": {
+          "Size": 10240,
+        },
         "MemorySize": 3008,
         "PackageType": "Image",
         "Role": {


### PR DESCRIPTION
Fixes #14 