### PR TITLE
fix: failed to install with pnpm

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -59,9 +59,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'security',
   ],
   gitignore: ['*.js', '*.d.ts', 'cdk.out/', '!test/*.integ.snapshot/**/*'],
-  bin: {
-    0: './assets',
-  },
   githubOptions: {
     pullRequestLintOptions: {
       semanticTitleOptions: {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "type": "git",
     "url": "https://github.com/go-to-k/image-scanner-with-trivy"
   },
-  "bin": {
-    "0": "./assets"
-  },
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",


### PR DESCRIPTION
If the bin field exists in the package.json of the package to be installed, pnpm reads the file to get the shebang and arguments for the specified file.
However, the current package.json specifies the `assets` directory in the bin field, resulting in an `EISDIR` error when installing.
This PR remove the unused bin field so that pnpm can install this package.