### PR TITLE
test: improve integ test

### DIFF
--- a/test/integ.image-scanner-with-trivy.ts
+++ b/test/integ.image-scanner-with-trivy.ts
@@ -43,6 +43,7 @@ new ImageScannerWithTrivy(stack, 'ImageScannerWithTrivyWithAllOptions', {
   scanLogsOutput: ScanLogsOutput.cloudWatchLogs({ logGroup }),
   defaultLogGroupRemovalPolicy: RemovalPolicy.DESTROY,
   defaultLogGroupRetentionDays: RetentionDays.ONE_DAY,
+  suppressErrorOnRollback: true,
 });
 
 // This test checks that the default log group is not created and that the existing log group is used.


### PR DESCRIPTION
Add the new property `suppressErrorOnRollback` to `ImageScannerWithTrivyWithAllOptions` in the integ test.

The default value is true, so the snapshots will not be changed.

```ts
new ImageScannerWithTrivy(stack, 'ImageScannerWithTrivyWithAllOptions', {
  // ...
  suppressErrorOnRollback: true,
});
```