### PR TITLE
fix: missing IAM policies for cloudformation describe-stacks even if suppressErrorOnRollback is enabled

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,12 +1,20 @@
-## Contribution
+# Contribution
 
-### Build for Code Bundle and API.md
+## Build for Code Bundle and API.md
 
 ```sh
 yarn build
 ```
 
-### Update Snapshots in Integration Tests
+## Execute Unit Tests, Linting, and Integration Tests
+
+```sh
+yarn tsc -p tsconfig.dev.json
+
+yarn test
+```
+
+## Update Snapshots in Integration Tests
 
 ```sh
 yarn tsc -p tsconfig.dev.json

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -228,6 +228,13 @@ exports[`ImageScannerWithTrivy Snapshot test 1`] = `
               "Resource": "*",
             },
             {
+              "Action": "cloudformation:DescribeStacks",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AWS::StackId",
+              },
+            },
+            {
               "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",

--- a/test/integ.image-scanner-with-trivy.js.snapshot/ImageScannerWithTrivyStack.assets.json
+++ b/test/integ.image-scanner-with-trivy.js.snapshot/ImageScannerWithTrivyStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "8ced7f7963c65cb6f745680e99bc8a83892fc24f71ca8cc494570fd4f9f16213": {
+    "3f8d4d5a729c63c17e8c70fc7136817b9cad2e968fe99c1b1d6aebcfda2692f6": {
       "source": {
         "path": "ImageScannerWithTrivyStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8ced7f7963c65cb6f745680e99bc8a83892fc24f71ca8cc494570fd4f9f16213.json",
+          "objectKey": "3f8d4d5a729c63c17e8c70fc7136817b9cad2e968fe99c1b1d6aebcfda2692f6.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ.image-scanner-with-trivy.js.snapshot/ImageScannerWithTrivyStack.template.json
+++ b/test/integ.image-scanner-with-trivy.js.snapshot/ImageScannerWithTrivyStack.template.json
@@ -238,6 +238,13 @@
        "Resource": "*"
       },
       {
+       "Action": "cloudformation:DescribeStacks",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "AWS::StackId"
+       }
+      },
+      {
        "Action": [
         "logs:CreateLogStream",
         "logs:PutLogEvents"

--- a/test/integ.image-scanner-with-trivy.js.snapshot/TestDefaultTestDeployAssert12909640.assets.json
+++ b/test/integ.image-scanner-with-trivy.js.snapshot/TestDefaultTestDeployAssert12909640.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "0028b0e98f39f135b207f1e2495bfea1260984addaf146491a95ef818d8f9c1b": {
+    "f1c5e64c85630cae4e79569b7dd4e50815eed6fade45c71c4c1686c0745c9c1a": {
       "source": {
         "path": "TestDefaultTestDeployAssert12909640.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0028b0e98f39f135b207f1e2495bfea1260984addaf146491a95ef818d8f9c1b.json",
+          "objectKey": "f1c5e64c85630cae4e79569b7dd4e50815eed6fade45c71c4c1686c0745c9c1a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ.image-scanner-with-trivy.js.snapshot/TestDefaultTestDeployAssert12909640.template.json
+++ b/test/integ.image-scanner-with-trivy.js.snapshot/TestDefaultTestDeployAssert12909640.template.json
@@ -35,7 +35,7 @@
     "outputPaths": [
      "events.0.message"
     ],
-    "salt": "1753354438845"
+    "salt": "1753422426105"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/integ.image-scanner-with-trivy.js.snapshot/manifest.json
+++ b/test/integ.image-scanner-with-trivy.js.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/8ced7f7963c65cb6f745680e99bc8a83892fc24f71ca8cc494570fd4f9f16213.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3f8d4d5a729c63c17e8c70fc7136817b9cad2e968fe99c1b1d6aebcfda2692f6.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -316,6 +316,30 @@
                 {}
               ]
             }
+          },
+          {
+            "type": "aws:cdk:analytics:method",
+            "data": {
+              "addToPrincipalPolicy": [
+                {}
+              ]
+            }
+          },
+          {
+            "type": "aws:cdk:analytics:method",
+            "data": {
+              "addToPrincipalPolicy": [
+                {}
+              ]
+            }
+          },
+          {
+            "type": "aws:cdk:analytics:method",
+            "data": {
+              "addToPrincipalPolicy": [
+                {}
+              ]
+            }
           }
         ],
         "/ImageScannerWithTrivyStack/Custom::ImageScannerWithTrivyCustomResourceLambda470b6343d267f753226c1e99f09f319a/ServiceRole/ImportServiceRole": [
@@ -348,6 +372,30 @@
             "data": {
               "attachToRole": [
                 "*"
+              ]
+            }
+          },
+          {
+            "type": "aws:cdk:analytics:method",
+            "data": {
+              "addStatements": [
+                {}
+              ]
+            }
+          },
+          {
+            "type": "aws:cdk:analytics:method",
+            "data": {
+              "addStatements": [
+                {}
+              ]
+            }
+          },
+          {
+            "type": "aws:cdk:analytics:method",
+            "data": {
+              "addStatements": [
+                {}
               ]
             }
           },
@@ -832,7 +880,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0028b0e98f39f135b207f1e2495bfea1260984addaf146491a95ef818d8f9c1b.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f1c5e64c85630cae4e79569b7dd4e50815eed6fade45c71c4c1686c0745c9c1a.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ.image-scanner-with-trivy.js.snapshot/tree.json
+++ b/test/integ.image-scanner-with-trivy.js.snapshot/tree.json
@@ -526,6 +526,13 @@
                                   "Resource": "*"
                                 },
                                 {
+                                  "Action": "cloudformation:DescribeStacks",
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Ref": "AWS::StackId"
+                                  }
+                                },
+                                {
                                   "Action": [
                                     "logs:CreateLogStream",
                                     "logs:PutLogEvents"
@@ -604,6 +611,21 @@
                           "addStatements": [
                             {}
                           ]
+                        },
+                        {
+                          "addStatements": [
+                            {}
+                          ]
+                        },
+                        {
+                          "addStatements": [
+                            {}
+                          ]
+                        },
+                        {
+                          "addStatements": [
+                            {}
+                          ]
                         }
                       ]
                     }
@@ -637,6 +659,21 @@
                     {
                       "attachInlinePolicy": [
                         "*"
+                      ]
+                    },
+                    {
+                      "addToPrincipalPolicy": [
+                        {}
+                      ]
+                    },
+                    {
+                      "addToPrincipalPolicy": [
+                        {}
+                      ]
+                    },
+                    {
+                      "addToPrincipalPolicy": [
+                        {}
                       ]
                     },
                     {


### PR DESCRIPTION
Added the `suppressErrorOnRollback` in the [PR](https://github.com/go-to-k/image-scanner-with-trivy/pull/30).

After introduced the property, in the scanner lambda, `cloudformation:DescribeStacks` is called if the `suppressErrorOnRollback` is true and any vulnerability is detected.

But the construct is missing necessary policies, so the policies are added now.